### PR TITLE
fix list.focusBackground color

### DIFF
--- a/themes/Supernova-color-theme.json
+++ b/themes/Supernova-color-theme.json
@@ -56,7 +56,7 @@
 		"list.activeSelectionForeground": "#D6DEEB",
 		"list.invalidItemForeground": "#E97178",
 		"list.dropBackground": "#141820",
-		"list.focusBackground": "#1C222D",
+		"list.focusBackground": "#141820",
 		"list.focusForeground": "#D6DEEB",
 		"list.highlightForeground": "#D6DEEB",
 		"list.hoverBackground": "#141820",


### PR DESCRIPTION
`"dropdown.listBackground": "#1C222D",`
`"dropdown.foreground": "#D6DEEB",`
`"list.focusBackground": "#1C222D",`
`"list.focusForeground": "#D6DEEB",`

No way to tell which item is selected from dropdown suggestion list. Before and after:

![53681494-57f0e480-3d25-11e9-995f-40041f510dae](https://user-images.githubusercontent.com/4502661/53684017-0a837000-3d43-11e9-9bcc-155e7710e56a.png)
