### PR TITLE
fix scrollbar slider color

### DIFF
--- a/themes/Supernova-color-theme.json
+++ b/themes/Supernova-color-theme.json
@@ -37,9 +37,9 @@
 
 		// Scrollbars
 		"scrollbar.shadow": "#141820",
-		"scrollbarSlider.activeBackground": "#141820",
-		"scrollbarSlider.background": "#141820",
-		"scrollbarSlider.hoverBackground": "#141820",
+		"scrollbarSlider.activeBackground": "#141820AA",
+		"scrollbarSlider.background": "#141820BB",
+		"scrollbarSlider.hoverBackground": "#141820DD",
 
 		// Badges
 		"badge.background": "#8D71FD",


### PR DESCRIPTION
`scrollbarSlider.*background` should transparent a bit to show color info behind it.

`"scrollbarSlider.activeBackground": "#141820AA",` A bit lighter than hovering in order to see colors behind more clearer.

`"scrollbarSlider.background": "#141820BB",` 73% opacity

`"scrollbarSlider.hoverBackground": "#141820DD",` More darker when hovering